### PR TITLE
Move global style block to sibling of <Head> so it is included in the…

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -13,12 +13,12 @@ export class Layout extends React.Component<{}, {}> {
             name="viewport"
             content="width=device-width, initial-scale=1, shrink-to-fit=no"
           />
-          {/*language=PostCSS*/}
-          <style jsx global>{`//global stylesheet
-
-          `}
-          </style>
         </Head>
+        {/*language=PostCSS*/}
+        <style jsx global>{`//global stylesheet
+
+        `}
+        </style>
         <Header/>
         <main>
           {children}


### PR DESCRIPTION
… rendered `<head>`

Fixes deptno/next.js-typescript-starter-kit#7